### PR TITLE
chore: naming custom domain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,8 @@ npm install
 
 Go to `src/app/app.modules.ts`
 
-Replace <YOUR DOMAIN> (4 times) with the domain of your own ZITADEL instance
-Replace <YOUR APPS CLIENT ID HERE> (once) with your application clientId
+Replace ${CUSTOM_DOMAIN} (4 times) with the Custom Domain of your own ZITADEL instance
+Replace ${CLIENT_ID} (once) with your application clientId
 
 5. Start the developer application/server:
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ To run the example you need to create your ZITADEL instance. If you not already 
 1. Create ZITADEL instance on zitadel.cloud
 2. Login to your ZITADEL instance and create an app according to the [example](https://zitadel.com/docs/examples/login/angular)
 3. Go to app.module.ts
-   1. Replace <YOUR DOMAIN> (4 times) with the domain of your own ZITADEL instance
-   2. Replace <YOUR APPS CLIENT ID HERE> (once) with the client id created in the app in step 2
+   1. Replace ${CUSTOM_DOMAIN} (4 times) with the Custom Domain of your own ZITADEL instance
+   2. Replace ${CLIENT_ID} (once) with the client id created in the app in step 2
 
 ## Development server
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,8 +16,8 @@ const authConfig: AuthConfig = {
   scope: 'openid profile email offline_access',
   responseType: 'code',
   oidc: true,
-  clientId: '<YOUR APPS CLIENT ID HERE>',
-  issuer: '<YOUR DOMAIN>', // eg. https://acme-jdo9fs.zitadel.cloud
+  clientId: '${CLIENT_ID}',
+  issuer: '${CUSTOM_DOMAIN}', // eg. https://acme-jdo9fs.zitadel.cloud
   redirectUri: 'http://localhost:4200/auth/callback',
   postLogoutRedirectUri: 'http://localhost:4200/signedout',
   requireHttps: false, // required for running locally
@@ -34,7 +34,7 @@ const stateHandlerFn = (stateHandler: StatehandlerService) => {
         AppRoutingModule,
         OAuthModule.forRoot({
             resourceServer: {
-                allowedUrls: ['<YOUR DOMAIN>/admin/v1', '<YOUR DOMAIN>/management/v1', '<YOUR DOMAIN>/auth/v1/'],
+                allowedUrls: ['${CUSTOM_DOMAIN}/admin/v1', '${CUSTOM_DOMAIN}/management/v1', '${CUSTOM_DOMAIN}/auth/v1/'],
                 sendAccessToken: true,
             },
         })], providers: [


### PR DESCRIPTION
As part of https://github.com/zitadel/zitadel/issues/11296, we consistently refer to domains identifying an instance as Custom Domain. This PR also changes to the preferred placeholder style.