### PR TITLE
fix!: harden token storage, interceptor allowlist, and auth-param detection

### DIFF
--- a/src/lib/auth/auth.service.ts
+++ b/src/lib/auth/auth.service.ts
@@ -9,7 +9,6 @@ import {
   User,
   UserManager,
   UserManagerSettings,
-  WebStorageStateStore,
 } from 'oidc-client-ts';
 import { BehaviorSubject, from, Observable, of } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
@@ -17,6 +16,12 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { OIDC_CONFIG_TOKEN } from '../oidc-config.token.js';
 import { applyOidcConfigDefaults, ZitadelScopeConfig } from '../utils.js';
 import { hasRole } from '../has-role.js';
+
+/**
+ * Session-storage key under which the post-login return path is stored before a
+ * signin redirect, and read back after the callback completes.
+ */
+const RETURN_TO_KEY = 'zitadel:angular-auth:returnTo';
 
 /**
  * Root-provided service that wraps the `oidc-client-ts` `UserManager` and
@@ -109,16 +114,7 @@ export class AuthService {
    * @private
    */
   private initializeUserManager(): void {
-    const withDefaults = applyOidcConfigDefaults(this.config);
-
-    this.config = withDefaults.userStore
-      ? withDefaults
-      : {
-          ...withDefaults,
-          userStore: new WebStorageStateStore({
-            store: window.localStorage,
-          }),
-        };
+    this.config = applyOidcConfigDefaults(this.config);
 
     this.userManager = new UserManager(this.config);
 
@@ -353,7 +349,7 @@ export class AuthService {
    */
   public setAuthGuardInterceptedPathname(path?: string): void {
     const pathToStore = path || window.location.pathname;
-    localStorage.setItem('authGuardInterceptedPathname', pathToStore);
+    sessionStorage.setItem(RETURN_TO_KEY, pathToStore);
   }
 
   /**
@@ -362,7 +358,7 @@ export class AuthService {
    * @returns The stored pathname, or `'/'` if none was stored.
    */
   public getAuthGuardInterceptedPathname(): string {
-    return localStorage.getItem('authGuardInterceptedPathname') || '/';
+    return sessionStorage.getItem(RETURN_TO_KEY) || '/';
   }
 
   /**
@@ -383,12 +379,12 @@ export class AuthService {
   }
 
   /**
-   * Cleans up user session and local storage after sign-out.
+   * Cleans up user session and session storage after sign-out.
    * @private
    */
   private cleanupAfterSignout(): void {
     this.user$.next(null);
     void this.userManager.removeUser();
-    localStorage.removeItem('authGuardInterceptedPathname');
+    sessionStorage.removeItem(RETURN_TO_KEY);
   }
 }

--- a/src/lib/auth/authz-token.interceptor.ts
+++ b/src/lib/auth/authz-token.interceptor.ts
@@ -8,10 +8,10 @@ import { ZITADEL_API_URLS } from '../oidc-config.token.js';
  * access token to outgoing requests as an `Authorization` header. When the user
  * is not authenticated, the request is forwarded unchanged.
  *
- * When an allowlist is configured via {@link ZITADEL_API_URLS}, the token is
- * only attached to requests whose URL starts with one of the configured
- * prefixes; an empty allowlist (the default) preserves the attach-when-
- * authenticated behavior.
+ * The token is only attached to requests whose URL starts with one of the
+ * prefixes configured via {@link ZITADEL_API_URLS}. The default allowlist is
+ * empty, so no token is attached until you opt specific API prefixes in. This
+ * prevents leaking the access token to third-party origins.
  *
  * @param req - The outgoing HTTP request.
  * @param next - The next handler in the interceptor chain.
@@ -29,8 +29,7 @@ export const authzTokenInterceptor: HttpInterceptorFn = (req, next) => {
   const authService = inject(AuthService);
   const apiUrls = inject(ZITADEL_API_URLS, { optional: true }) ?? [];
 
-  const isAllowlisted =
-    apiUrls.length === 0 || apiUrls.some((url) => req.url.startsWith(url));
+  const isAllowlisted = apiUrls.some((url) => req.url.startsWith(url));
 
   if (authService.isAuthenticated() && isAllowlisted) {
     req = req.clone({

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -68,36 +68,31 @@ export function applyOidcConfigDefaults(
 }
 
 /**
- * Determines whether the given query string contains the OAuth/OIDC redirect
- * callback parameters (`code` + `state`, or an `error`) that signal an
- * in-progress authorization response.
+ * Detects whether the current URL contains an OIDC authorization response,
+ * i.e. a `code`/`error` together with a `state` parameter, in either the
+ * query string (`response_mode: query`) or the fragment
+ * (`response_mode: fragment`).
  *
- * This is a pure helper with no Angular dependency, useful for deciding whether
- * the current location is an OIDC callback before invoking the callback flow.
- *
- * @param searchParams - A query string (e.g. `window.location.search`) or a
- *   pre-parsed {@link URLSearchParams}. Defaults to `''`.
- * @returns `true` when auth callback parameters are present, otherwise `false`.
+ * @param location - The location to inspect. Defaults to `window.location`.
+ * @returns `true` when the URL looks like an authorization response.
  *
  * @example
  * ```ts
  * import { hasAuthParams } from '@zitadel/angular-auth';
  *
- * if (hasAuthParams(window.location.search)) {
+ * if (hasAuthParams() && !auth.isAuthenticated()) {
  *   await auth.signinCallback();
  * }
  * ```
  */
-export function hasAuthParams(
-  searchParams: string | URLSearchParams = '',
-): boolean {
-  const params =
-    typeof searchParams === 'string'
-      ? new URLSearchParams(searchParams)
-      : searchParams;
+export const hasAuthParams = (location = window.location): boolean => {
+  const isAuthResponse = (params: URLSearchParams): boolean =>
+    Boolean((params.get('code') || params.get('error')) && params.get('state'));
 
-  const hasCodeAndState = params.has('code') && params.has('state');
-  const hasError = params.has('error');
+  // response_mode: query
+  const queryParams = new URLSearchParams(location.search);
+  // response_mode: fragment
+  const fragmentParams = new URLSearchParams(location.hash.replace('#', '?'));
 
-  return hasCodeAndState || hasError;
-}
+  return isAuthResponse(queryParams) || isAuthResponse(fragmentParams);
+};

--- a/test/auth.service.test.ts
+++ b/test/auth.service.test.ts
@@ -29,7 +29,6 @@ let nextManager: UserManager;
 
 jest.unstable_mockModule('oidc-client-ts', () => ({
   UserManager: jest.fn(() => nextManager),
-  WebStorageStateStore: jest.fn(),
 }));
 
 const { AuthService } = await import('../src/lib/auth/auth.service.js');
@@ -76,6 +75,7 @@ const buildHarness = (
 describe('AuthService', () => {
   beforeEach(() => {
     localStorage.clear();
+    sessionStorage.clear();
     jest.spyOn(console, 'error').mockImplementation(() => undefined);
   });
 
@@ -243,13 +243,13 @@ describe('AuthService', () => {
 
   it('should clean up the session after signoutCallback', async () => {
     const { service, manager } = buildHarness();
-    localStorage.setItem('authGuardInterceptedPathname', '/dash');
+    sessionStorage.setItem('zitadel:angular-auth:returnTo', '/dash');
 
     await service.signoutCallback('http://localhost/logout');
 
     expect(service.user()).toBeNull();
     expect(manager.removeUser).toHaveBeenCalled();
-    expect(localStorage.getItem('authGuardInterceptedPathname')).toBeNull();
+    expect(sessionStorage.getItem('zitadel:angular-auth:returnTo')).toBeNull();
   });
 
   it('should re-throw and still clean up when signoutCallback fails', async () => {
@@ -386,5 +386,19 @@ describe('AuthService', () => {
     expect(
       (service as unknown as { config: UserManagerSettings }).config.userStore,
     ).toBe(store);
+  });
+
+  it('should not override userStore when none is provided', () => {
+    const router = { navigate: jest.fn(async () => true) };
+    nextManager = createFakeUserManager();
+    const injector = Injector.create({ providers: [] });
+    const service = runInInjectionContext(
+      injector,
+      () => new AuthService({ ...baseConfig }, router as unknown as Router),
+    );
+
+    expect(
+      (service as unknown as { config: UserManagerSettings }).config.userStore,
+    ).toBeUndefined();
   });
 });

--- a/test/authz-token.interceptor.test.ts
+++ b/test/authz-token.interceptor.test.ts
@@ -57,7 +57,7 @@ describe('authzTokenInterceptor', () => {
       user: () => ({ access_token: 'tok-123' }),
     } as unknown as Partial<AuthService>;
 
-    const result = run(auth, req, next);
+    const result = run(auth, req, next, ['https://example.com']);
 
     expect(req.clone).toHaveBeenCalledWith({
       setHeaders: { Authorization: 'Bearer tok-123' },
@@ -110,8 +110,8 @@ describe('authzTokenInterceptor', () => {
     expect(blockedNext).toHaveBeenCalledWith(blocked.req);
   });
 
-  it('should attach the token to all requests when no allowlist is configured', () => {
-    const { req, cloned } = makeRequest('https://anything.example.com/path');
+  it('should not attach the token when no allowlist is configured', () => {
+    const { req } = makeRequest('https://anything.example.com/path');
     const handled = of({} as HttpEvent<unknown>);
     const next = jest.fn(() => handled) as unknown as HttpHandlerFn;
     const auth = {
@@ -121,10 +121,8 @@ describe('authzTokenInterceptor', () => {
 
     const result = run(auth, req, next, []);
 
-    expect(req.clone).toHaveBeenCalledWith({
-      setHeaders: { Authorization: 'Bearer tok-123' },
-    });
-    expect(next).toHaveBeenCalledWith(cloned);
+    expect(req.clone).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(req);
     expect(result).toBe(handled);
   });
 });

--- a/test/hasAuthParams.test.ts
+++ b/test/hasAuthParams.test.ts
@@ -1,30 +1,27 @@
 import { describe, expect, it } from '@jest/globals';
 import { hasAuthParams } from '../src/lib/utils.js';
 
+const loc = (search: string, hash: string): Location =>
+  ({ search, hash }) as Location;
+
 describe('hasAuthParams', () => {
   it('should detect code + state in the query string', () => {
-    expect(hasAuthParams('?code=abc&state=xyz')).toBe(true);
+    expect(hasAuthParams(loc('?code=abc&state=xyz', ''))).toBe(true);
   });
 
   it('should detect error + state in the query string', () => {
-    expect(hasAuthParams('?error=access_denied&state=xyz')).toBe(true);
+    expect(hasAuthParams(loc('?error=access_denied&state=xyz', ''))).toBe(true);
   });
 
   it('should detect code + state in the fragment', () => {
-    // Angular's `hasAuthParams` takes a query string / URLSearchParams rather
-    // than parsing the location itself, so the fragment's params are passed in
-    // directly to keep the assertion meaningful.
-    const fragmentParams = new URLSearchParams('code=abc&state=xyz');
-    expect(hasAuthParams(fragmentParams)).toBe(true);
+    expect(hasAuthParams(loc('', '#code=abc&state=xyz'))).toBe(true);
   });
 
   it('should return false without a state parameter', () => {
-    expect(hasAuthParams('?code=abc')).toBe(false);
+    expect(hasAuthParams(loc('?code=abc', ''))).toBe(false);
   });
 
   it('should return false for an unrelated URL', () => {
-    expect(hasAuthParams('?foo=bar&baz=qux')).toBe(false);
-    expect(hasAuthParams('')).toBe(false);
-    expect(hasAuthParams()).toBe(false);
+    expect(hasAuthParams(loc('?foo=bar&baz=qux', ''))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Aligns `angular-auth`'s runtime behavior with `react-auth`/`vue-auth` (the reference implementations), closing three behavioral divergences found in a cross-SDK security/harmonization audit. All Angular-only; React/Vue already behaved this way.

- **Token storage (security):** stop overriding the `oidc-client-ts` `userStore` to `localStorage`; use the default `sessionStorage` like React/Vue. Tokens no longer persist across sessions or remain script-readable after the tab closes.
- **Interceptor allowlist (security):** an empty `ZITADEL_API_URLS` allowlist now attaches the bearer token to **no** requests (was: every origin), preventing token leakage to third-party APIs. Configure prefixes to opt in.
- **`hasAuthParams` (parity/correctness):** now takes a `Location` (default `window.location`) and detects both query- and fragment-mode responses requiring `state` — matching React/Vue. Was a query-string-only helper that ignored the fragment.
- Return path moves from `localStorage` to `sessionStorage` under the namespaced key `zitadel:angular-auth:returnTo`.

## Test plan
- [x] 76 unit tests pass (updated interceptor + hasAuthParams + storage tests)
- [x] typecheck, lint, build (ngc AOT), format, depcheck all green

> [!WARNING]
> Breaking change — semantic-release will publish **2.0.0**. Tokens move to sessionStorage; the interceptor requires `ZITADEL_API_URLS`; `hasAuthParams` signature changed.